### PR TITLE
fix mew-search layout

### DIFF
--- a/src/components/MewSearch/MewSearch.vue
+++ b/src/components/MewSearch/MewSearch.vue
@@ -57,7 +57,7 @@
         @click="onSearch"
         width="64"
         depressed
-        :class="[isCompact ? 'margin-offset' : '', 'search-btn ml-10']"
+        :class="[isCompact ? 'margin-offset' : '', $vuetify.breakpoint.smAndDown ? 'ml-2' : 'ml-4', 'search-btn']"
         color="primary"
       >
         <v-icon color="white">


### PR DESCRIPTION
Developer: Reduce space between text and chevron down icon
Developer: reduce search buttons space on mobile to 16px instead of ml-10