### PR TITLE
devop: add borderSize prop to mew-token-container

### DIFF
--- a/src/components/MewTokenContainer/MewTokenContainer.vue
+++ b/src/components/MewTokenContainer/MewTokenContainer.vue
@@ -4,6 +4,10 @@
   <!-- ===================================================================================== -->
   <div
     class="mew-token-container d-flex align-center justify-center"
+    :style="{
+      height: borderSize ? borderSize : getSize,
+      width: borderSize ? borderSize : getSize
+    }"
   >
     <!-- ===================================================================================== -->
     <!-- Loading State -->
@@ -15,7 +19,7 @@
       :width="getSize"
       type="avatar"
     />
-    
+
     <!-- ===================================================================================== -->
     <!-- Img -->
     <!-- ===================================================================================== -->
@@ -25,7 +29,7 @@
       :src="img || ethTokenPlaceholder"
       :alt="name"
       loading="lazy"
-    >
+    />
 
     <!-- ===================================================================================== -->
     <!-- Img Placeholder -->
@@ -61,6 +65,10 @@ export default {
     size: {
       type: String,
       default: 'small'
+    },
+    borderSize: {
+      type: String,
+      default: ''
     },
     /**
      * Token name. Used for placeholder if there is no icon img.
@@ -118,12 +126,14 @@ export default {
       if (this.size.toLowerCase() === this.sizeOptions.small) {
         return '24px';
       }
-
       if (this.size.toLowerCase() === this.sizeOptions.medium) {
         return '32px';
       }
+      if (this.size.toLowerCase() === this.sizeOptions.large) {
+        return '52px';
+      }
 
-      return '52px';
+      return this.size;
     }
   }
 };
@@ -134,7 +144,6 @@ export default {
   * has to be global styles to override vuetify
   */
 .mew-token-container {
-  height: 100%;
   overflow: hidden;
   background-color: var(--v-white-base);
   border-radius: 50%;

--- a/stories/MewTokenContainer/MewTokenContainer.mdx
+++ b/stories/MewTokenContainer/MewTokenContainer.mdx
@@ -8,7 +8,8 @@ import './../GlobalStorybook.scss'
 
 ## Overview
 The mew-token-container component is used to display token icons found on the interface. 
-There are 3 **size** prop options: small (24px), medium(32px), and large(52px).Size small is used as default. 
+There are 3 **size** prop options: small (24px), medium(32px), and large(52px).Size small is used as default. Also a pixel value is accepted.
+To use **borderSize** prop, you must give pixel value to **size** prop.
 Acceptable icon prop formats are ‘.png’ and ‘.svg’. If the **img** prop is not specified, the placeholder is used.
 ## Props
 <Props of={MewTokenContainer} />

--- a/stories/MewTokenContainer/MewTokenContainer.stories.js
+++ b/stories/MewTokenContainer/MewTokenContainer.stories.js
@@ -29,7 +29,7 @@ export const MEWTokenContainer = () => ({
       default: text('size', 'small')
     },
     borderSize: {
-      default: text('borderSize', '')
+      default: text('border-size', '')
     },
     img: {
       default: files('img', '.png, .svg', '')

--- a/stories/MewTokenContainer/MewTokenContainer.stories.js
+++ b/stories/MewTokenContainer/MewTokenContainer.stories.js
@@ -1,7 +1,6 @@
 import {
   withKnobs,
   boolean,
-  optionsKnob,
   text,
   files
 } from '@storybook/addon-knobs';
@@ -20,12 +19,6 @@ export default {
   decorators: [withKnobs]
 };
 
-const sizeOptions = {
-  small: 'small',
-  medium: 'medium',
-  large: 'large'
-}
-
 export const MEWTokenContainer = () => ({
   components: { MewTokenContainer },
   props: {
@@ -33,7 +26,10 @@ export const MEWTokenContainer = () => ({
       default: boolean('dark mode ?', false)
     },
     size: {
-      default: optionsKnob('size', sizeOptions, sizeOptions.small, { display: 'inline-radio' })
+      default: text('size', 'small')
+    },
+    borderSize: {
+      default: text('borderSize', '')
     },
     img: {
       default: files('img', '.png, .svg', '')
@@ -55,6 +51,7 @@ export const MEWTokenContainer = () => ({
     <br />
     <mew-token-container
       :size="size"
+      :border-size="borderSize"
       :img="img"
       :name="name"
       :loading="loading"


### PR DESCRIPTION
Add borderSize prop to give padding between icon and container

![1](https://user-images.githubusercontent.com/9893774/180946775-a2ba2edd-1239-465b-9d75-99fe03e054be.png)
