### PR TITLE
devop: add border size prop to mew-token-container

### DIFF
--- a/src/components/MewTokenContainer/MewTokenContainer.vue
+++ b/src/components/MewTokenContainer/MewTokenContainer.vue
@@ -4,6 +4,10 @@
   <!-- ===================================================================================== -->
   <div
     class="mew-token-container d-flex align-center justify-center"
+    :style="{
+      height: borderSize ? borderSize : getSize,
+      width: borderSize ? borderSize : getSize
+    }"
   >
     <!-- ===================================================================================== -->
     <!-- Loading State -->
@@ -15,7 +19,7 @@
       :width="getSize"
       type="avatar"
     />
-    
+
     <!-- ===================================================================================== -->
     <!-- Img -->
     <!-- ===================================================================================== -->
@@ -25,7 +29,7 @@
       :src="img || ethTokenPlaceholder"
       :alt="name"
       loading="lazy"
-    >
+    />
 
     <!-- ===================================================================================== -->
     <!-- Img Placeholder -->
@@ -61,6 +65,10 @@ export default {
     size: {
       type: String,
       default: 'small'
+    },
+    borderSize: {
+      type: String,
+      default: ''
     },
     /**
      * Token name. Used for placeholder if there is no icon img.
@@ -118,12 +126,14 @@ export default {
       if (this.size.toLowerCase() === this.sizeOptions.small) {
         return '24px';
       }
-
       if (this.size.toLowerCase() === this.sizeOptions.medium) {
         return '32px';
       }
+      if (this.size.toLowerCase() === this.sizeOptions.large) {
+        return '52px';
+      }
 
-      return '52px';
+      return this.size;
     }
   }
 };
@@ -134,7 +144,6 @@ export default {
   * has to be global styles to override vuetify
   */
 .mew-token-container {
-  height: 100%;
   overflow: hidden;
   background-color: var(--v-white-base);
   border-radius: 50%;

--- a/src/components/MewTokenContainer/MewTokenContainer.vue
+++ b/src/components/MewTokenContainer/MewTokenContainer.vue
@@ -29,7 +29,7 @@
       :src="img || ethTokenPlaceholder"
       :alt="name"
       loading="lazy"
-    />
+    >
 
     <!-- ===================================================================================== -->
     <!-- Img Placeholder -->
@@ -66,6 +66,9 @@ export default {
       type: String,
       default: 'small'
     },
+    /**
+     * Set a custom border size for icon.
+     */
     borderSize: {
       type: String,
       default: ''

--- a/stories/MewTokenContainer/MewTokenContainer.stories.js
+++ b/stories/MewTokenContainer/MewTokenContainer.stories.js
@@ -35,6 +35,9 @@ export const MEWTokenContainer = () => ({
     size: {
       default: optionsKnob('size', sizeOptions, sizeOptions.small, { display: 'inline-radio' })
     },
+    borderSize: {
+      default: boolean('border-size', false)
+    },
     img: {
       default: files('img', '.png, .svg', '')
     },
@@ -55,6 +58,7 @@ export const MEWTokenContainer = () => ({
     <br />
     <mew-token-container
       :size="size"
+      :border-size="borderSize"
       :img="img"
       :name="name"
       :loading="loading"

--- a/stories/MewTokenContainer/MewTokenContainer.stories.js
+++ b/stories/MewTokenContainer/MewTokenContainer.stories.js
@@ -36,7 +36,7 @@ export const MEWTokenContainer = () => ({
       default: optionsKnob('size', sizeOptions, sizeOptions.small, { display: 'inline-radio' })
     },
     borderSize: {
-      default: boolean('border-size', false)
+      default: text('border-size', '')
     },
     img: {
       default: files('img', '.png, .svg', '')


### PR DESCRIPTION
add border size prop to mew-token-container to give custom border size for token icons
![Screenshot from 2022-08-08 18-48-32](https://user-images.githubusercontent.com/9893774/183545759-9fc67fe0-b1db-4457-8da6-b9c2db9797c5.png)
