### PR TITLE
fix: mew-tooltip word wrap issue

### DIFF
--- a/src/components/MewTooltip/MewTooltip.vue
+++ b/src/components/MewTooltip/MewTooltip.vue
@@ -80,4 +80,8 @@ export default {
     word-break: break-all;
   }
 }
+.tippy-tooltip.light-theme .tippy-content {
+  word-break: break-word !important;
+  text-align: left !important;
+}
 </style>


### PR DESCRIPTION
fix mew-tooltip word wrap issue

![Screenshot from 2022-08-08 19-30-56](https://user-images.githubusercontent.com/9893774/183550713-e78bf217-e881-4aac-a166-b0e53400d330.png)
