### PR TITLE
Devop: persistent hint for normal hint

### DIFF
--- a/src/components/MewAddressSelect/MewAddressSelect.vue
+++ b/src/components/MewAddressSelect/MewAddressSelect.vue
@@ -16,7 +16,7 @@
     :disabled="disabled"
     :error-messages="errorMessages"
     :hint="hint || resolvedAddr || ''"
-    :persistent-hint="resolvedAddr.length > 0"
+    :persistent-hint="resolvedAddr.length > 0 || hint.length > 0"
     :rules="rules"
     :no-data-text="noDataText"
     :menu-props="{ value: dropdown, closeOnClick: true }"


### PR DESCRIPTION
Make hint stay if it is not empty. Used for Kleros nametags and Unstoppable Domains.
![image](https://user-images.githubusercontent.com/36307949/189446814-c92841b7-e1f3-476d-b38a-15d3a85cfab4.png)
