### PR TITLE
fix: fix mew-tooltip horizontal alignment

### DIFF
--- a/src/components/MewTooltip/MewTooltip.vue
+++ b/src/components/MewTooltip/MewTooltip.vue
@@ -1,7 +1,7 @@
 <template>
   <tippy-component
     class="mew-tooltip"
-    style="line-height: 1px"
+    style="line-height: initial"
     arrow
     theme="light"
     :max-width="maxWidth"
@@ -9,18 +9,10 @@
   >
     <!-- Popover trigger -->
     <template #trigger>
-      <v-icon
-        v-if="!hideIcon"
-        class="cursor-pointer"
-        color="searchText"
-        small
-      >
+      <v-icon v-if="!hideIcon" class="cursor-pointer" color="searchText" small>
         mdi-information
       </v-icon>
-      <slot
-        name="activatorSlot"
-        class="d-flex"
-      />
+      <slot name="activatorSlot" class="d-flex" />
     </template>
     <!-- Popover content -->
     <slot name="contentSlot" />


### PR DESCRIPTION
fix mew-tooltip horizontal alignment

![Screenshot from 2022-09-12 19-10-08](https://user-images.githubusercontent.com/9893774/189797610-236b1393-cc97-4ac1-85df-b6d98ff0d43d.png)
![Screenshot from 2022-09-12 19-10-11](https://user-images.githubusercontent.com/9893774/189797612-2b275dc9-bdd9-412b-8a50-9382a5af3636.png)
