### PR TITLE
fix: address selector showing invalid identicon when address is empty

### DIFF
--- a/src/components/MewAddressSelect/MewAddressSelect.vue
+++ b/src/components/MewAddressSelect/MewAddressSelect.vue
@@ -32,7 +32,7 @@
     <!-- ===================================================================================== -->
     <template #prepend-inner>
       <div
-        v-if="!isValidAddress"
+        v-if="!isValidAddress || !blockieHash"
         class="blockie-placeholder mr-1 selectHover"
       />
       <mew-blockie
@@ -87,9 +87,7 @@
         class="dropdown-icon-container d-flex align-center justify-center cursor-pointer full-height"
         @click="toggle"
       >
-        <v-icon class="mew-heading-1 mx-5">
-          mdi-chevron-down
-        </v-icon>
+        <v-icon class="mew-heading-1 mx-5"> mdi-chevron-down </v-icon>
       </div>
     </template>
 
@@ -115,10 +113,7 @@
             v-if="!item.resolvedAddr || item.resolvedAddr === ''"
             :hash="item.address"
           />
-          <span
-            v-else
-            class="mew-address"
-          >{{ item.address }}</span>
+          <span v-else class="mew-address">{{ item.address }}</span>
         </div>
         <div class="overline primary--text font-weight-medium ml-3">
           {{ item.nickname }}
@@ -255,6 +250,13 @@ export default {
     errorMessages: {
       type: [String, Array],
       default: ''
+    },
+    /**
+     * Clear address
+     */
+    clearAddress: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -287,10 +289,15 @@ export default {
         : this.addressValue.address || this.addressValue;
     }
   },
+  watch: {
+    clearAddress() {
+      this.clear();
+    }
+  },
   methods: {
     /**
-    * Clears the v-model value.
-    */
+     * Clears the v-model value.
+     */
     clear() {
       this.addressValue = '';
     },

--- a/src/components/MewBlockie/MewBlockie.vue
+++ b/src/components/MewBlockie/MewBlockie.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <div
+      v-show="address"
       style="position: relative"
       :style="`width: ${width}; height: ${height}`"
     >
@@ -9,24 +10,16 @@
         :src="blockieImg"
         alt="Blockie Image"
         style="display: block; border-radius: 50%"
-      >
+      />
 
       <!--
       =====================================================================
       Inset shadow on edge of blockie image
       =====================================================================
       -->
-      <div
-        v-if="!flat"
-        class="inset-shadow"
-      />
+      <div v-if="!flat" class="inset-shadow" />
     </div>
-    <img
-      v-if="currency"
-      alt="icon"
-      class="currency-icon"
-      :src="currency"
-    >
+    <img v-if="currency" alt="icon" class="currency-icon" :src="currency" />
   </div>
 </template>
 


### PR DESCRIPTION
address selector showing invalid identicon when address is empty